### PR TITLE
Allow SB open when to_call within blind and add test

### DIFF
--- a/poker-teaching-v1-alpha/packages/poker_core/suggest/policy_preflop.py
+++ b/poker-teaching-v1-alpha/packages/poker_core/suggest/policy_preflop.py
@@ -39,9 +39,17 @@ def decide_sb_open(
 ) -> PreflopDecision | None:
     """SB first-in open sizing when combo in range."""
 
-    if obs.street != "preflop" or obs.to_call != 0:
+    if obs.street != "preflop":
         return None
     if obs.pot_type != "limped" or not obs.first_to_act:
+        return None
+    # 允许 SB 盲注差额（to_call <= 1bb）仍视为首入开局
+    try:
+        to_call = float(obs.to_call or 0)
+        bb = float(obs.bb or 0)
+    except (TypeError, ValueError):
+        return None
+    if to_call > max(bb, 0.0):
         return None
 
     betlike = pick_betlike_action(obs.acts)


### PR DESCRIPTION
## Summary
- allow SB first-in open logic to trigger even when to_call is within one blind
- add a preflop v1 test covering SB open suggestions when legal actions include call

## Testing
- pytest tests/test_pfv1_preflop.py

------
https://chatgpt.com/codex/tasks/task_e_68d0016002808326b10de37cc8bdb88f